### PR TITLE
Use coffeelint's getConfig function to resolve "extends"

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,8 +41,7 @@ function loadConfig(options, callback) {
 			var options;
 			var err;
 			try {
-				options = getConfig(path)
-				console.log(options)
+				options = getConfig(path);
 			} catch(e) {
 				err = e;
 			}

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 	Author Scott Beck @bline
 */
 var coffeelint = require("coffeelint").lint;
+var getConfig = require("coffeelint/lib/configfinder").getConfig;
 var stripJsonComments = require("strip-json-comments");
 var loaderUtils = require("loader-utils");
 var fs = require("fs");
@@ -25,8 +26,8 @@ function loadConfig(options, callback) {
 			return merge({});
 		} else {
 			this.addDependency(path);
-			var file = fs.readFileSync(path, "utf8");
-			return merge(JSON.parse(stripJsonComments(file)));
+			var file = getConfig(path);
+			return file;
 		}
 	}
 	else {
@@ -37,18 +38,15 @@ function loadConfig(options, callback) {
 			}
 
 			this.addDependency(path);
-			fs.readFile(path, "utf8", function(err, file) {
-				var options;
-				if (!err) {
-					try {
-						options = merge(JSON.parse(stripJsonComments(file)));
-					}
-					catch(e) {
-						err = e;
-					}
-				}
-				callback(err, options);
-			});
+			var options;
+			var err;
+			try {
+				options = getConfig(path)
+				console.log(options)
+			} catch(e) {
+				err = e;
+			}
+			callback(err, options);
 		}.bind(this));
 	}
 }
@@ -138,4 +136,3 @@ module.exports = function(input) {
 
 	}.bind(this));
 }
-


### PR DESCRIPTION
Coffeelint supports an "extends" config parameter that can merge shareable configs. It's not part of the base coffeescript.lint function but they do expose their config loader (https://github.com/clutchski/coffeelint/blob/master/src/configfinder.coffee#L104-L116) which takes care of it.

This PR uses that config loader, rather than just reading the configFile

The only downside is they don't offer an async version 
